### PR TITLE
Send all configured events to caduceus

### DIFF
--- a/src/talaria/dispatcher_test.go
+++ b/src/talaria/dispatcher_test.go
@@ -30,9 +30,12 @@ import (
 
 func testDispatcherIgnoredEvent(t *testing.T) {
 	var (
-		assert                     = assert.New(t)
-		require                    = require.New(t)
-		dispatcher, outbounds, err = NewDispatcher(NewTestOutboundMeasures(), nil, nil)
+		assert     = assert.New(t)
+		require    = require.New(t)
+		outbounder = &Outbounder{
+			EventEndpoints: map[string]interface{}{"default": []string{"http://endpoint1.com"}},
+		}
+		dispatcher, outbounds, err = NewDispatcher(NewTestOutboundMeasures(), outbounder, nil)
 	)
 
 	require.NotNil(dispatcher)
@@ -338,6 +341,28 @@ func testDispatcherOnDeviceEventDispatchTo(t *testing.T) {
 	}
 }
 
+func testDispatcherOnDeviceEventEnabledEventType(t *testing.T) {
+	var (
+		assert     = assert.New(t)
+		require    = require.New(t)
+		outbounder = &Outbounder{
+			EventEndpoints: map[string]interface{}{"default": []string{"http://endpoint1.com"}},
+			ServerEventsToDispatch: []string{
+				"Disconnect",
+				"Connect",
+			},
+		}
+		dispatcher, outbounds, err = NewDispatcher(NewTestOutboundMeasures(), outbounder, nil)
+	)
+
+	require.NotNil(dispatcher)
+	require.NotNil(outbounds)
+	require.NoError(err)
+
+	dispatcher.OnDeviceEvent(&device.Event{Type: device.Connect})
+	assert.Equal(1, len(outbounds))
+}
+
 func TestDispatcher(t *testing.T) {
 	t.Run("IgnoredEvent", testDispatcherIgnoredEvent)
 	t.Run("Unroutable", testDispatcherUnroutable)
@@ -347,5 +372,6 @@ func TestDispatcher(t *testing.T) {
 		t.Run("EventTimeout", testDispatcherOnDeviceEventEventTimeout)
 		t.Run("FilterError", testDispatcherOnDeviceEventFilterError)
 		t.Run("DispatchTo", testDispatcherOnDeviceEventDispatchTo)
+		t.Run("EnabledEventType", testDispatcherOnDeviceEventEnabledEventType)
 	})
 }

--- a/src/talaria/outbounder_test.go
+++ b/src/talaria/outbounder_test.go
@@ -143,6 +143,8 @@ func testOutbounderDefaults(t *testing.T) {
 		assert.Equal(DefaultMaxIdleConnsPerHost, transport.MaxIdleConnsPerHost)
 		assert.Equal(DefaultIdleConnTimeout, transport.IdleConnTimeout)
 		assert.Equal(DefaultClientTimeout, o.clientTimeout())
+
+		assert.Equal(make(map[string]struct{}), o.serverEventsToDispatch())
 	}
 }
 
@@ -168,7 +170,11 @@ func testOutbounderConfiguration(t *testing.T) {
 				"maxIdleConns": 5681,
 				"maxIdleConnsPerHost": 99,
 				"idleConnTimeout": "2m17s"
-			}
+			},
+			"serverEventsToDispatch": [
+				"Connect",
+				"Disconnect"
+			]
 		}`)
 
 		v = viper.New()
@@ -199,6 +205,11 @@ func testOutbounderConfiguration(t *testing.T) {
 	assert.Equal(uint(281), o.outboundQueueSize())
 	assert.Equal(uint(17), o.workerPoolSize())
 	assert.Equal(time.Minute+10*time.Second, o.clientTimeout())
+
+	_, exists := o.serverEventsToDispatch()["Connect"]
+	assert.True(exists)
+	_, exists = o.serverEventsToDispatch()["Disconnect"]
+	assert.True(exists)
 
 	transport := o.transport()
 	assert.Equal(5681, transport.MaxIdleConns)


### PR DESCRIPTION
This change adds a behavior to send device state change events to Caduceus based on **configured** event types, via the existing outbounder configurations.

We take into account whether or not the event contains a WRP message, and if not we create a `SimpleEvent` message so that Caduceus will be able to unmarshal the event.

This leverages the existing internal events such as [Connect](https://github.com/Comcast/webpa-common/blob/093c2cf50ca8094c5186345caf568324b35598e3/device/manager.go#L184) and [Disconect](https://github.com/Comcast/webpa-common/blob/093c2cf50ca8094c5186345caf568324b35598e3/device/manager.go#L228) and will allow us to take real-time actions based on the CPE state.

If left unconfigured, this change will not have impact on existing configurations.

The following is an example of configuring the Connect and Disconnect events.
```json
{
  "device": {
    "outbound": {
      "serverEventsToDispatch": [ "Connect", "Disconnect" ]
    }
  }
}
```