### PR TITLE
hacky check to ensure only basic auth is used

### DIFF
--- a/WRPHandler.go
+++ b/WRPHandler.go
@@ -43,6 +43,14 @@ func wrpRouterHandler(logger *zap.Logger, router device.Router, ctxlogger func(c
 	}
 
 	return func(w wrphttp.ResponseWriter, r *wrphttp.Request) {
+		// HOTFIX: only support basic auth for now, so as to avoid allowing themis
+		// to issue JWTs for this endpoint.
+		if _, _, ok := r.Original.BasicAuth(); !ok {
+			logger.Error("only basic auth is supported")
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
 		deviceRequest := &device.Request{
 			Message:  &r.Entity.Message,
 			Format:   r.Entity.Format,


### PR DESCRIPTION
This hack prevents a JWT from themis, or anywhere, being used to invoke the /send endpoint.

In theory, this should just be temporary.  The real fix should be have /send take a SAT.