### PR TITLE
pass custom prometheus registry into wrpkafka publisher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ src/vendor
 +src/talaria/debug
 +src/talaria/output
 
+#artifacts
+cmd/device-simulator/device-simulator
+
  # config
 -src/talaria/talaria.json
 +src/talaria/talaria.json

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ func setupDefaultConfigValues(v *viper.Viper) {
 	v.SetDefault(RehasherServicesConfigKey, []string{applicationName})
 }
 
-func newDeviceManager(logger *zap.Logger, r xmetrics.Registry, tf *touchstone.Factory, v *viper.Viper) (device.Manager, devicegate.Interface, *consul.ConsulWatcher, error) {
+func newDeviceManager(logger *zap.Logger, r xmetrics.Registry, tf *touchstone.Factory, v *viper.Viper, promReg prometheus.Registerer) (device.Manager, devicegate.Interface, *consul.ConsulWatcher, error) {
 	deviceOptions, err := device.NewOptions(logger, v.Sub(device.DeviceManagerKey))
 	if err != nil {
 		return nil, nil, nil, err
@@ -81,7 +81,7 @@ func newDeviceManager(logger *zap.Logger, r xmetrics.Registry, tf *touchstone.Fa
 	}
 
 	// Create and start Kafka publisher (pass metrics for integration)
-	kafkaPublisher, err := NewKafkaPublisher(logger, v, &om)
+	kafkaPublisher, err := NewKafkaPublisher(logger, v, &om, promReg)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create kafka publisher: %w", err)
 	}
@@ -184,7 +184,7 @@ func talaria(arguments []string) int {
 	v.UnmarshalKey("touchstone", &tsConfig)
 	tf := touchstone.NewFactory(tsConfig, logger, promReg)
 
-	manager, filterGate, watcher, err := newDeviceManager(logger, metricsRegistry, tf, v)
+	manager, filterGate, watcher, err := newDeviceManager(logger, metricsRegistry, tf, v, promReg)
 	if err != nil {
 		logger.Error("unable to create device manager", zap.Error(err))
 		return 2

--- a/publisher.go
+++ b/publisher.go
@@ -112,16 +112,17 @@ type wrpKafkaPublisher interface {
 
 // kafkaPublisher implements the Publisher interface using wrpkafka
 type kafkaPublisher struct {
-	config           *KafkaConfig
-	logger           *zap.Logger
-	publisher        wrpKafkaPublisher
-	started          bool
-	publisherFactory func(*KafkaConfig) (wrpKafkaPublisher, error) // for testing
-	metrics          *OutboundMeasures                             // for Prometheus metrics
+	config             *KafkaConfig
+	logger             *zap.Logger
+	publisher          wrpKafkaPublisher
+	started            bool
+	publisherFactory   func(*KafkaConfig, prometheus.Registerer) (wrpKafkaPublisher, error) // for testing
+	metrics            *OutboundMeasures                                                    // for Prometheus metrics
+	prometheusRegistry prometheus.Registerer
 }
 
 // NewKafkaPublisher creates a new Kafka publisher from Viper configuration
-func NewKafkaPublisher(logger *zap.Logger, v *viper.Viper, om *OutboundMeasures) (Publisher, error) {
+func NewKafkaPublisher(logger *zap.Logger, v *viper.Viper, om *OutboundMeasures, promReg prometheus.Registerer) (Publisher, error) {
 	if v == nil {
 		return nil, errors.New("viper config is required")
 	}
@@ -168,15 +169,16 @@ func NewKafkaPublisher(logger *zap.Logger, v *viper.Viper, om *OutboundMeasures)
 	)
 
 	return &kafkaPublisher{
-		config:           &config,
-		logger:           logger,
-		publisherFactory: publisherFactory,
-		metrics:          om,
+		config:             &config,
+		logger:             logger,
+		publisherFactory:   publisherFactory,
+		metrics:            om,
+		prometheusRegistry: promReg,
 	}, nil
 }
 
 // publisherFactory creates a real wrpkafka.Publisher
-func publisherFactory(config *KafkaConfig) (wrpKafkaPublisher, error) {
+func publisherFactory(config *KafkaConfig, promReg prometheus.Registerer) (wrpKafkaPublisher, error) {
 
 	// Create wrpkafka publisher
 	publisher := &wrpkafka.Publisher{
@@ -189,6 +191,7 @@ func publisherFactory(config *KafkaConfig) (wrpKafkaPublisher, error) {
 		AllowAutoTopicCreation: config.AllowAutoTopicCreation,
 		PrometheusNamespace:    config.PrometheusNamespace,
 		PrometheusSubsystem:    config.PrometheusSubsystem,
+		PrometheusRegisterer:   promReg,
 	}
 
 	// Configure TLS if enabled
@@ -254,7 +257,7 @@ func (k *kafkaPublisher) Start() error {
 	}
 
 	// Create the wrpkafka publisher using the factory
-	publisher, err := k.publisherFactory(k.config)
+	publisher, err := k.publisherFactory(k.config, k.prometheusRegistry)
 	if err != nil {
 		return fmt.Errorf("failed to create wrpkafka publisher: %w", err)
 	}

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -75,7 +76,7 @@ func TestKafkaPublisher_Start(t *testing.T) {
 			kp := &kafkaPublisher{
 				config: config,
 				logger: zap.NewNop(),
-				publisherFactory: func(c *KafkaConfig) (wrpKafkaPublisher, error) {
+				publisherFactory: func(c *KafkaConfig, promReg prometheus.Registerer) (wrpKafkaPublisher, error) {
 					if tt.factoryError != nil {
 						return nil, tt.factoryError
 					}
@@ -582,7 +583,7 @@ func TestDefaultPublisherFactory(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			publisher, err := publisherFactory(tt.config)
+			publisher, err := publisherFactory(tt.config, nil)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -656,7 +657,7 @@ func TestKafkaPublisher_Lifecycle(t *testing.T) {
 	kp := &kafkaPublisher{
 		config: config,
 		logger: zap.NewNop(),
-		publisherFactory: func(c *KafkaConfig) (wrpKafkaPublisher, error) {
+		publisherFactory: func(c *KafkaConfig, promReg prometheus.Registerer) (wrpKafkaPublisher, error) {
 			return mockPub, nil
 		},
 		metrics: &om,
@@ -878,7 +879,7 @@ func TestNewKafkaPublisher(t *testing.T) {
 			}
 
 			logger := zap.NewNop()
-			publisher, err := NewKafkaPublisher(logger, v, nil)
+			publisher, err := NewKafkaPublisher(logger, v, nil, nil)
 
 			if tt.expectError {
 				assert.Error(t, err)
@@ -916,7 +917,7 @@ func TestKafkaPublisher_NotStarted(t *testing.T) {
 	v.Set("kafka.topic", "test-topic")
 
 	logger := zap.NewNop()
-	publisher, err := NewKafkaPublisher(logger, v, nil)
+	publisher, err := NewKafkaPublisher(logger, v, nil, nil)
 	require.NoError(t, err)
 
 	msg := &wrp.Message{


### PR DESCRIPTION
franz-go metrics were using the default prometheus registry, not the one the rest of the app uses, so they were not being scraped