### PR TITLE
Update to bascule v1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/kafka v0.42.0
 	github.com/thedevsaddam/gojsonq/v2 v2.5.2
 	github.com/twmb/franz-go v1.21.2
-	github.com/xmidt-org/bascule v0.11.7
+	github.com/xmidt-org/bascule v1.1.1
 	github.com/xmidt-org/candlelight v0.2.12
 	github.com/xmidt-org/clortho v0.1.13
 	github.com/xmidt-org/httpaux v0.4.3

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,8 @@ github.com/twmb/franz-go/plugin/kprom v1.4.0 h1:gRdB03h/BoBTIgr3obudwio6q3FbrFvb
 github.com/twmb/franz-go/plugin/kprom v1.4.0/go.mod h1:0j4hawUp3/R8tdn+uV0movy1HIaRbqsPPdMaeWNq0pc=
 github.com/ugorji/go/codec v1.2.14 h1:yOQvXCBc3Ij46LRkRoh4Yd5qK6LVOgi0bYOXfb7ifjw=
 github.com/ugorji/go/codec v1.2.14/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/xmidt-org/bascule v0.11.7 h1:+pasCXM+irFuBB4HgO67xC7VHuygjmlmFjEpJdBGXeQ=
-github.com/xmidt-org/bascule v0.11.7/go.mod h1:SyAUlH8Y77Iq97u2d4Q7d9ldE7pCqNuQq7bFcl05zwo=
+github.com/xmidt-org/bascule v1.1.1 h1:Njx4utxYKKQqfNxy/tyVZbzuj04RsZrVQsq4NcclGaY=
+github.com/xmidt-org/bascule v1.1.1/go.mod h1:gqPlJVhz5/5yJnp6XZTaJlQr+/objL6xFK2KA3VBqyI=
 github.com/xmidt-org/candlelight v0.2.12 h1:N8vxeWTdLG79ogRZxZ7oY/+FRnQLkh4mfSB8Zq1BHo4=
 github.com/xmidt-org/candlelight v0.2.12/go.mod h1:d7U+IycdZprO40vIEp29Oc31gjeMYEu5OfzRlujkwXI=
 github.com/xmidt-org/chronon v0.1.13 h1:e6bW7sPIfZqVf9npbTvlAYPteqjSRIh/mR0BEb9lgQo=

--- a/middleware.go
+++ b/middleware.go
@@ -30,20 +30,20 @@ func DeviceMetadataMiddleware(getLogger func(ctx context.Context) *zap.Logger) a
 			metadata := new(device.Metadata)
 			metadata.SetSessionID(ksuid.New().String())
 
-			if auth, ok := bascule.FromContext(ctx); ok {
-				if tokenAttributes, ok := auth.Token.Attributes().(RawAttributes); ok {
+			if token, ok := bascule.Get(ctx); ok {
+				if tokenAttributes, ok := token.(RawAttributes); ok {
 					metadata.SetClaims(tokenAttributes.GetRawAttributes())
-				} else {
+				} else if accessor, ok := token.(bascule.AttributesAccessor); ok {
 					claimsMap := make(map[string]interface{})
-					if partnerIDClaim, ok := auth.Token.Attributes().Get(device.PartnerIDClaimKey); ok {
+					if partnerIDClaim, ok := accessor.Get(device.PartnerIDClaimKey); ok {
 						claimsMap[device.PartnerIDClaimKey] = partnerIDClaim
 					}
 
-					if trustClaim, ok := auth.Token.Attributes().Get(device.TrustClaimKey); ok {
+					if trustClaim, ok := accessor.Get(device.TrustClaimKey); ok {
 						claimsMap[device.TrustClaimKey] = trustClaim
 					}
 
-					if accountIDClaim, ok := auth.Token.Attributes().Get(device.AccountIDClaimKey); ok {
+					if accountIDClaim, ok := accessor.Get(device.AccountIDClaimKey); ok {
 						claimsMap[device.AccountIDClaimKey] = accountIDClaim
 					}
 

--- a/primaryHandler.go
+++ b/primaryHandler.go
@@ -15,16 +15,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/viper"
 	"github.com/xmidt-org/bascule"
+	"github.com/xmidt-org/bascule/basculehttp"
 	"github.com/xmidt-org/clortho/clorthometrics"
 	"github.com/xmidt-org/clortho/clorthozap"
 	"github.com/xmidt-org/sallust"
 	"github.com/xmidt-org/touchstone"
 	"go.uber.org/zap"
 
-	// nolint:staticcheck
-	"github.com/xmidt-org/bascule/basculechecks"
-	// nolint:staticcheck
-	"github.com/xmidt-org/bascule/basculehttp"
 	"github.com/xmidt-org/clortho"
 
 	// nolint:staticcheck
@@ -92,7 +89,32 @@ type JWTValidator struct {
 
 	// Leeway is used to set the amount of time buffer should be given to JWT
 	// time values, such as nbf
-	Leeway bascule.Leeway
+	Leeway Leeway
+}
+
+func authStatusCoder(request *http.Request, err error) int {
+	if request != nil {
+		if vars := mux.Vars(request); vars != nil && vars["version"] == v2 {
+			if errors.Is(err, bascule.ErrInvalidCredentials) {
+				return http.StatusBadRequest
+			}
+
+			return http.StatusForbidden
+		}
+	}
+
+	switch {
+	case errors.Is(err, bascule.ErrMissingCredentials):
+		return http.StatusUnauthorized
+	case errors.Is(err, bascule.ErrBadCredentials):
+		return http.StatusUnauthorized
+	case errors.Is(err, bascule.ErrInvalidCredentials):
+		return http.StatusBadRequest
+	case errors.Is(err, bascule.ErrUnauthorized):
+		return http.StatusForbidden
+	default:
+		return http.StatusForbidden
+	}
 }
 
 func getInboundTimeout(v *viper.Viper) time.Duration {
@@ -130,36 +152,7 @@ func NewPrimaryHandler(logger *zap.Logger, manager device.Manager, v *viper.Vipe
 
 		jwtAuthEnforcer   = NoOpConstructor
 		basicAuthEnforcer = NoOpConstructor
-
-		deviceAuthRules  = bascule.Validators{} //auth rules for device registration endpoints
-		serviceAuthRules = bascule.Validators{} //auth rules for everything else
-
 	)
-
-	authCounter, err := tf.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: basculehttp.AuthValidationOutcome,
-			Help: "Counter for success and failure reason results through bascule",
-		}, basculehttp.ServerLabel, basculehttp.OutcomeLabel)
-	if err != nil {
-		return nil, err
-	}
-
-	listener, err := basculehttp.NewMetricListener(
-		&basculehttp.AuthValidationMeasures{ValidationOutcome: authCounter},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	jwtAuthConstructorOptions := []basculehttp.COption{
-		basculehttp.WithCLogger(getLogger),
-		basculehttp.WithCErrorResponseFunc(listener.OnErrorResponse),
-	}
-	basicAuthConstructorOptions := []basculehttp.COption{
-		basculehttp.WithCLogger(getLogger),
-		basculehttp.WithCErrorResponseFunc(listener.OnErrorResponse),
-	}
 
 	if v.IsSet(JWTValidatorConfigKey) {
 		var jwtVal JWTValidator
@@ -204,29 +197,68 @@ func NewPrimaryHandler(logger *zap.Logger, manager device.Manager, v *viper.Vipe
 		resolver.AddListener(cml)
 		resolver.AddListener(czl)
 
-		jwtAuthConstructorOptions = append(jwtAuthConstructorOptions, basculehttp.WithTokenFactory("Bearer", basculehttp.BearerTokenFactory{
-			DefaultKeyID: DefaultKeyID,
-			Resolver:     resolver,
-			Parser:       bascule.DefaultJWTParser,
-			Leeway:       jwtVal.Leeway,
-		}))
+		authParser, err := basculehttp.NewAuthorizationParser(
+			basculehttp.WithScheme(basculehttp.SchemeBearer, &RawAttributesBearerTokenParser{
+				DefaultKeyID: DefaultKeyID,
+				Resolver:     resolver,
+				Leeway:       jwtVal.Leeway,
+			}),
+		)
+		if err != nil {
+			return nil, errors.New("failed to create JWT authorization parser")
+		}
 
-		deviceAuthRules = append(deviceAuthRules,
-			bascule.Validators{
-				basculechecks.NonEmptyPrincipal(),
-				basculechecks.NonEmptyType(),
-				basculechecks.ValidType([]string{"jwt"}),
-			})
+		jwtValidators := bascule.Validators[*http.Request]{
+			basculehttp.AsValidator(nonEmptyPrincipalValidator),
+			basculehttp.AsValidator(validJWTTokenTypeValidator),
+		}
+
+		authenticator, err := basculehttp.NewAuthenticator(
+			bascule.WithTokenParsers(authParser),
+			bascule.WithValidators[*http.Request](jwtValidators...),
+		)
+		if err != nil {
+			return nil, errors.New("failed to create JWT authenticator")
+		}
+
+		jwtMiddleware, err := basculehttp.NewMiddleware(
+			basculehttp.WithAuthenticator(authenticator),
+			basculehttp.WithErrorStatusCoder(authStatusCoder),
+		)
+		if err != nil {
+			return nil, errors.New("failed to create JWT auth middleware")
+		}
+
+		jwtAuthEnforcer = jwtMiddleware.Then
 	}
 
 	if v.IsSet(ServiceBasicAuthConfigKey) {
 		userPassMap := buildUserPassMap(logger, v.GetStringSlice(ServiceBasicAuthConfigKey))
 
 		if len(userPassMap) > 0 {
-			basicAuthConstructorOptions = append(basicAuthConstructorOptions,
-				basculehttp.WithTokenFactory("Basic", basculehttp.BasicTokenFactory(userPassMap)))
+			authParser, err := basculehttp.NewAuthorizationParser(
+				basculehttp.WithScheme(basculehttp.SchemeBasic, basicAllowedTokenParser{allowed: userPassMap}),
+			)
+			if err != nil {
+				return nil, errors.New("failed to create basic authorization parser")
+			}
 
-			serviceAuthRules = append(serviceAuthRules, basculechecks.AllowAll())
+			authenticator, err := basculehttp.NewAuthenticator(
+				bascule.WithTokenParsers(authParser),
+			)
+			if err != nil {
+				return nil, errors.New("failed to create basic authenticator")
+			}
+
+			basicMiddleware, err := basculehttp.NewMiddleware(
+				basculehttp.WithAuthenticator(authenticator),
+				basculehttp.WithErrorStatusCoder(authStatusCoder),
+			)
+			if err != nil {
+				return nil, errors.New("failed to create basic auth middleware")
+			}
+
+			basicAuthEnforcer = basicMiddleware.Then
 		}
 	}
 
@@ -261,54 +293,8 @@ func NewPrimaryHandler(logger *zap.Logger, manager device.Manager, v *viper.Vipe
 		wrpRouterHandler = withDeviceAccessCheck(logger, wrpRouterHandler, deviceAccessCheck)
 	}
 
-	jwtAuthConstructor := basculehttp.NewConstructor(jwtAuthConstructorOptions...)
-	basicAuthConstructor := basculehttp.NewConstructor(basicAuthConstructorOptions...)
-	jwtAuthConstructorLegacy := basculehttp.NewConstructor(append([]basculehttp.COption{
-		basculehttp.WithCErrorHTTPResponseFunc(basculehttp.LegacyOnErrorHTTPResponse),
-	}, jwtAuthConstructorOptions...)...)
-	basicAuthConstructorLegacy := basculehttp.NewConstructor(append([]basculehttp.COption{
-		basculehttp.WithCErrorHTTPResponseFunc(basculehttp.LegacyOnErrorHTTPResponse),
-	}, basicAuthConstructorOptions...)...)
-
-	jwtAuthEnforcer = basculehttp.NewEnforcer(
-		basculehttp.WithELogger(getLogger),
-		basculehttp.WithRules("Bearer", deviceAuthRules),
-		basculehttp.WithEErrorResponseFunc(listener.OnErrorResponse),
-	)
-	basicAuthEnforcer = basculehttp.NewEnforcer(
-		basculehttp.WithELogger(getLogger),
-		basculehttp.WithRules("Basic", serviceAuthRules),
-		basculehttp.WithEErrorResponseFunc(listener.OnErrorResponse),
-	)
-	jwtAuthChain := alice.New(setLogger(logger), jwtAuthConstructor, jwtAuthEnforcer, basculehttp.NewListenerDecorator(listener))
-	basicAuthChain := alice.New(setLogger(logger), basicAuthConstructor, basicAuthEnforcer, basculehttp.NewListenerDecorator(listener))
-	jwtAuthChainV2 := alice.New(setLogger(logger), jwtAuthConstructorLegacy, jwtAuthEnforcer, basculehttp.NewListenerDecorator(listener))
-	basicAuthChainV2 := alice.New(setLogger(logger), basicAuthConstructorLegacy, basicAuthEnforcer, basculehttp.NewListenerDecorator(listener))
-
-	versionCompatibleJWTAuth := alice.New(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(r http.ResponseWriter, req *http.Request) {
-			vars := mux.Vars(req)
-			if vars != nil {
-				if vars["version"] == v2 {
-					jwtAuthChainV2.Then(next).ServeHTTP(r, req)
-					return
-				}
-			}
-			jwtAuthChain.Then(next).ServeHTTP(r, req)
-		})
-	})
-	versionCompatibleBasicAuth := alice.New(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(r http.ResponseWriter, req *http.Request) {
-			vars := mux.Vars(req)
-			if vars != nil {
-				if vars["version"] == v2 {
-					basicAuthChainV2.Then(next).ServeHTTP(r, req)
-					return
-				}
-			}
-			basicAuthChain.Then(next).ServeHTTP(r, req)
-		})
-	})
+	versionCompatibleJWTAuth := alice.New(setLogger(logger), jwtAuthEnforcer)
+	versionCompatibleBasicAuth := alice.New(setLogger(logger), basicAuthEnforcer)
 
 	apiHandler.Handle("/device/send",
 		alice.New(

--- a/primaryHandler_test.go
+++ b/primaryHandler_test.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2017 Comcast Cable Communications Management, LLC
+// SPDX-License-Identifier: Apache-2.0
+package main
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/xmidt-org/bascule"
+)
+
+func TestAuthStatusCoder(t *testing.T) {
+	tests := []struct {
+		description string
+		req         *http.Request
+		err         error
+		expected    int
+	}{
+		{
+			description: "Missing Credentials",
+			err:         bascule.ErrMissingCredentials,
+			expected:    http.StatusUnauthorized,
+		},
+		{
+			description: "Bad Credentials",
+			err:         bascule.ErrBadCredentials,
+			expected:    http.StatusUnauthorized,
+		},
+		{
+			description: "Invalid Credentials",
+			err:         bascule.ErrInvalidCredentials,
+			expected:    http.StatusBadRequest,
+		},
+		{
+			description: "Unauthorized",
+			err:         bascule.ErrUnauthorized,
+			expected:    http.StatusForbidden,
+		},
+		{
+			description: "Unknown Error",
+			err:         errors.New("some error"),
+			expected:    http.StatusForbidden,
+		},
+		{
+			description: "V2 Invalid Credentials",
+			req:         mux.SetURLVars(httptest.NewRequest(http.MethodGet, "/api/v2/device/send", nil), map[string]string{"version": v2}),
+			err:         bascule.ErrInvalidCredentials,
+			expected:    http.StatusBadRequest,
+		},
+		{
+			description: "V2 Bad Credentials",
+			req:         mux.SetURLVars(httptest.NewRequest(http.MethodGet, "/api/v2/device/send", nil), map[string]string{"version": v2}),
+			err:         bascule.ErrBadCredentials,
+			expected:    http.StatusForbidden,
+		},
+		{
+			description: "V3 Invalid Credentials",
+			req:         mux.SetURLVars(httptest.NewRequest(http.MethodGet, "/api/v3/device/send", nil), map[string]string{"version": version}),
+			err:         bascule.ErrInvalidCredentials,
+			expected:    http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert.Equal(t, tc.expected, authStatusCoder(tc.req, tc.err))
+		})
+	}
+}

--- a/primaryHandler_test.go
+++ b/primaryHandler_test.go
@@ -11,9 +11,14 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/xmidt-org/bascule"
+	"github.com/xmidt-org/sallust"
+	"github.com/xmidt-org/touchstone"
+	"github.com/xmidt-org/webpa-common/v2/device"
 	"go.uber.org/zap"
 )
 
@@ -132,4 +137,171 @@ func TestBuildUserPassMap(t *testing.T) {
 	assert.False(t, hasMissingColonUser)
 	_, hasEmptyUser := decoded[""]
 	assert.False(t, hasEmptyUser)
+}
+
+// newTestTouchstoneFactory builds a touchstone.Factory with an isolated prometheus registry
+// suitable for use inside unit tests.
+func newTestTouchstoneFactory(t *testing.T) *touchstone.Factory {
+	t.Helper()
+	cfg := touchstone.Config{DefaultNamespace: "test", DefaultSubsystem: "primary"}
+	_, pr, err := touchstone.New(cfg)
+	require.NoError(t, err)
+	return touchstone.NewFactory(cfg, sallust.Default(), pr)
+}
+
+// newTestDeviceManager builds a real but unconfigured device.Manager for unit test fixtures.
+func newTestDeviceManager() device.Manager {
+	return device.NewManager(&device.Options{})
+}
+
+func TestBuildDeviceAccessCheck(t *testing.T) {
+	logger := zap.NewNop()
+	counter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "test_wrp_counter", Help: "test"},
+		[]string{reasonLabel, outcomeLabel},
+	)
+
+	validCheck := deviceAccessCheck{
+		Name:                 "partner-check",
+		DeviceCredentialPath: "partner-id",
+		WRPCredentialPath:    "partner-id",
+		Op:                   "contains",
+	}
+
+	tests := []struct {
+		description string
+		config      *deviceAccessCheckConfig
+		expectErr   bool
+	}{
+		{
+			description: "No Checks",
+			config:      &deviceAccessCheckConfig{Type: "enforce"},
+			expectErr:   true,
+		},
+		{
+			description: "Invalid Type",
+			config: &deviceAccessCheckConfig{
+				Type:   "unknown",
+				Checks: []deviceAccessCheck{validCheck},
+			},
+			expectErr: true,
+		},
+		{
+			description: "Invalid Check - Missing Name",
+			config: &deviceAccessCheckConfig{
+				Type: "enforce",
+				Checks: []deviceAccessCheck{
+					{DeviceCredentialPath: "path", WRPCredentialPath: "path", Op: "contains"},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			description: "Valid Enforce Type",
+			config: &deviceAccessCheckConfig{
+				Type:   "enforce",
+				Checks: []deviceAccessCheck{validCheck},
+			},
+		},
+		{
+			description: "Valid Monitor Type",
+			config: &deviceAccessCheckConfig{
+				Type:   "monitor",
+				Checks: []deviceAccessCheck{validCheck},
+			},
+		},
+		{
+			description: "Default Sep Applied",
+			config: &deviceAccessCheckConfig{
+				Type:   "monitor",
+				Sep:    "",
+				Checks: []deviceAccessCheck{validCheck},
+			},
+		},
+		{
+			description: "Custom Sep Applied",
+			config: &deviceAccessCheckConfig{
+				Type:   "monitor",
+				Sep:    "/",
+				Checks: []deviceAccessCheck{validCheck},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := buildDeviceAccessCheck(tc.config, logger, counter, newTestDeviceManager())
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestNewPrimaryHandler(t *testing.T) {
+	newViper := func() *viper.Viper { return viper.New() }
+
+	tests := []struct {
+		description string
+		setup       func(*viper.Viper)
+		expectErr   bool
+	}{
+		{
+			description: "Minimal Config",
+			setup:       func(v *viper.Viper) {},
+		},
+		{
+			description: "With Basic Auth",
+			setup: func(v *viper.Viper) {
+				v.Set(ServiceBasicAuthConfigKey, []string{
+					base64.StdEncoding.EncodeToString([]byte("user:pass")),
+				})
+			},
+		},
+		{
+			description: "With Basic Auth But Empty Entries",
+			setup: func(v *viper.Viper) {
+				v.Set(ServiceBasicAuthConfigKey, []string{"%%%"})
+			},
+		},
+		{
+			description: "Fail Open False",
+			setup: func(v *viper.Viper) {
+				v.Set(FailOpenConfigKey, false)
+			},
+		},
+		{
+			description: "DeviceAccessCheck Bad Config",
+			setup: func(v *viper.Viper) {
+				v.Set(DeviceAccessCheckConfigKey+".type", "enforce")
+				// no checks → buildDeviceAccessCheck returns error
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			v := newViper()
+			tc.setup(v)
+
+			tf := newTestTouchstoneFactory(t)
+			logger := zap.NewNop()
+			manager := newTestDeviceManager()
+			router := mux.NewRouter()
+
+			handler, err := NewPrimaryHandler(logger, manager, v, nil, nil, NoOpConstructor, tf, router)
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Nil(t, handler)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, handler)
+			}
+		})
+	}
 }

--- a/primaryHandler_test.go
+++ b/primaryHandler_test.go
@@ -3,14 +3,18 @@
 package main
 
 import (
+	"encoding/base64"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/xmidt-org/bascule"
+	"go.uber.org/zap"
 )
 
 func TestAuthStatusCoder(t *testing.T) {
@@ -63,6 +67,11 @@ func TestAuthStatusCoder(t *testing.T) {
 			err:         bascule.ErrInvalidCredentials,
 			expected:    http.StatusBadRequest,
 		},
+		{
+			description: "Nil Error",
+			err:         nil,
+			expected:    http.StatusForbidden,
+		},
 	}
 
 	for _, tc := range tests {
@@ -70,4 +79,57 @@ func TestAuthStatusCoder(t *testing.T) {
 			assert.Equal(t, tc.expected, authStatusCoder(tc.req, tc.err))
 		})
 	}
+}
+
+func TestGetInboundTimeout(t *testing.T) {
+	tests := []struct {
+		description string
+		value       string
+		expected    time.Duration
+	}{
+		{
+			description: "Valid Duration",
+			value:       "45s",
+			expected:    45 * time.Second,
+		},
+		{
+			description: "Invalid Duration Uses Default",
+			value:       "not-a-duration",
+			expected:    DefaultInboundTimeout,
+		},
+		{
+			description: "Empty Duration Uses Default",
+			value:       "",
+			expected:    DefaultInboundTimeout,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			v := viper.New()
+			v.Set(InboundTimeoutConfigKey, tc.value)
+
+			assert.Equal(t, tc.expected, getInboundTimeout(v))
+		})
+	}
+}
+
+func TestBuildUserPassMap(t *testing.T) {
+	logger := zap.NewNop()
+
+	validA := base64.StdEncoding.EncodeToString([]byte("userA:passA"))
+	validB := base64.StdEncoding.EncodeToString([]byte("userB:passB"))
+	invalidBase64 := "%%%"
+	missingColon := base64.StdEncoding.EncodeToString([]byte("userCpassC"))
+	emptyUser := base64.StdEncoding.EncodeToString([]byte(":passD"))
+
+	decoded := buildUserPassMap(logger, []string{validA, invalidBase64, missingColon, emptyUser, validB})
+
+	assert.Len(t, decoded, 2)
+	assert.Equal(t, "passA", decoded["userA"])
+	assert.Equal(t, "passB", decoded["userB"])
+	_, hasMissingColonUser := decoded["userCpassC"]
+	assert.False(t, hasMissingColonUser)
+	_, hasEmptyUser := decoded[""]
+	assert.False(t, hasEmptyUser)
 }

--- a/rawAttributes.go
+++ b/rawAttributes.go
@@ -8,7 +8,7 @@ import "github.com/xmidt-org/bascule"
 // with a token's attributes. It adds functionality on top of bascule Attributes by including
 // a Getter for all of a token's attributes, returning a map of the attributes
 type RawAttributes interface {
-	bascule.Attributes
+	bascule.AttributesAccessor
 	GetRawAttributes() map[string]interface{}
 }
 

--- a/tokenFactory.go
+++ b/tokenFactory.go
@@ -4,8 +4,7 @@ package main
 
 import (
 	"context"
-	"errors"
-	"net/http"
+	"fmt"
 
 	"github.com/golang-jwt/jwt"
 	"github.com/goph/emperror"
@@ -16,15 +15,47 @@ import (
 
 const (
 	jwtPrincipalKey = "sub"
+	jwtTokenType    = "jwt"
 )
 
-// RawAttributesBearerTokenFactory parses and does basic validation for a JWT token, creating a token with RawAttributes
-// instead of bascule processed attributes
-type RawAttributesBearerTokenFactory struct {
+// Leeway configures optional JWT time checks in seconds.
+type Leeway struct {
+	EXP int64 `json:"exp"`
+	NBF int64 `json:"nbf"`
+	IAT int64 `json:"iat"`
+}
+
+type tokenType interface {
+	TokenType() string
+}
+
+type rawAttributesJWTToken struct {
+	principal string
+	claims    RawAttributes
+}
+
+func (t *rawAttributesJWTToken) Principal() string {
+	return t.principal
+}
+
+func (t *rawAttributesJWTToken) Get(key string) (any, bool) {
+	if t == nil || t.claims == nil {
+		return nil, false
+	}
+
+	return t.claims.Get(key)
+}
+
+func (t *rawAttributesJWTToken) TokenType() string {
+	return jwtTokenType
+}
+
+// RawAttributesBearerTokenParser parses and validates JWT tokens into bascule tokens
+// that preserve all claims as RawAttributes.
+type RawAttributesBearerTokenParser struct {
 	DefaultKeyID string
 	Resolver     clortho.Resolver
-	Parser       bascule.JWTParser
-	Leeway       bascule.Leeway
+	Leeway       Leeway
 }
 
 func defaultKeyFunc(ctx context.Context, defaultKeyID string, resolver clortho.Resolver) jwt.Keyfunc {
@@ -42,49 +73,103 @@ func defaultKeyFunc(ctx context.Context, defaultKeyID string, resolver clortho.R
 	}
 }
 
-// ParseAndValidate expects the given value to be a JWT with a kid header.  The
-// kid should be resolvable by the Resolver and the JWT should be Parseable and
-// pass any basic validation checks done by the Parser.  If everything goes
-// well, a Token of type "jwt" is returned.
-func (r RawAttributesBearerTokenFactory) ParseAndValidate(ctx context.Context, _ *http.Request, _ bascule.Authorization, value string) (bascule.Token, error) {
+// Parse expects the given value to be a JWT with an optional kid header. The
+// kid should be resolvable by the Resolver and the JWT should pass signature
+// and temporal checks.
+func (r RawAttributesBearerTokenParser) Parse(ctx context.Context, value string) (bascule.Token, error) {
 	if len(value) == 0 {
-		return nil, errors.New("empty value")
+		return nil, bascule.ErrMissingCredentials
 	}
 
-	leewayclaims := bascule.ClaimsWithLeeway{
-		MapClaims: make(jwt.MapClaims),
-		Leeway:    r.Leeway,
-	}
-
-	jwtToken, err := r.Parser.ParseJWT(value, &leewayclaims, defaultKeyFunc(ctx, r.DefaultKeyID, r.Resolver))
+	claims := jwt.MapClaims{}
+	// Skip built-in claim validation so expiration checks are handled by
+	// validateTimeClaimsWithLeeway and honor configured leeway values.
+	parser := jwt.Parser{SkipClaimsValidation: true}
+	jwtToken, err := parser.ParseWithClaims(value, claims, defaultKeyFunc(ctx, r.DefaultKeyID, r.Resolver))
 	if err != nil {
-		return nil, emperror.Wrap(err, "failed to parse JWT")
+		return nil, bascule.ErrInvalidCredentials
 	}
 	if !jwtToken.Valid {
-		return nil, basculehttp.ErrInvalidToken
+		return nil, bascule.ErrBadCredentials
 	}
 
-	claims, ok := jwtToken.Claims.(*bascule.ClaimsWithLeeway)
-
-	if !ok {
-		return nil, emperror.Wrap(basculehttp.ErrUnexpectedClaims, "failed to parse JWT")
+	if err := validateTimeClaimsWithLeeway(claims, r.Leeway); err != nil {
+		return nil, bascule.ErrBadCredentials
 	}
 
-	claimsMap, err := claims.GetMap()
-	if err != nil {
-		return nil, emperror.WrapWith(err, "failed to get map of claims", "claims struct", claims)
+	claimsMap := make(map[string]interface{}, len(claims))
+	for k, v := range claims {
+		claimsMap[k] = v
 	}
 
 	jwtClaims := NewRawAttributes(claimsMap)
 
 	principalVal, ok := jwtClaims.Get(jwtPrincipalKey)
 	if !ok {
-		return nil, emperror.WrapWith(basculehttp.ErrInvalidPrincipal, "principal value not found", "principal key", jwtPrincipalKey, "jwtClaims", claimsMap)
+		return nil, bascule.ErrInvalidCredentials
 	}
 	principal, ok := principalVal.(string)
-	if !ok {
-		return nil, emperror.WrapWith(basculehttp.ErrInvalidPrincipal, "principal value not a string", "principal", principalVal)
+	if !ok || principal == "" {
+		return nil, bascule.ErrInvalidCredentials
 	}
 
-	return bascule.NewToken("jwt", principal, jwtClaims), nil
+	return &rawAttributesJWTToken{principal: principal, claims: jwtClaims}, nil
+}
+
+func validateTimeClaimsWithLeeway(claims jwt.MapClaims, leeway Leeway) error {
+	now := jwt.TimeFunc().Unix()
+
+	if !claims.VerifyExpiresAt(now+leeway.EXP, false) {
+		return fmt.Errorf("token is expired")
+	}
+
+	if !claims.VerifyIssuedAt(now-leeway.IAT, false) {
+		return fmt.Errorf("token used before issued")
+	}
+
+	if !claims.VerifyNotBefore(now-leeway.NBF, false) {
+		return fmt.Errorf("token is not valid yet")
+	}
+
+	return nil
+}
+
+func nonEmptyPrincipalValidator(token bascule.Token) error {
+	if token.Principal() == "" {
+		return fmt.Errorf("empty token principal")
+	}
+
+	return nil
+}
+
+func validJWTTokenTypeValidator(token bascule.Token) error {
+	tt, ok := token.(tokenType)
+	if !ok || tt.TokenType() != jwtTokenType {
+		return fmt.Errorf("unexpected token type")
+	}
+
+	return nil
+}
+
+type basicAllowedTokenParser struct {
+	allowed map[string]string
+}
+
+func (batp basicAllowedTokenParser) Parse(ctx context.Context, raw string) (bascule.Token, error) {
+	token, err := (basculehttp.BasicTokenParser{}).Parse(ctx, raw)
+	if err != nil {
+		return nil, err
+	}
+
+	var basicToken basculehttp.BasicToken
+	if !bascule.TokenAs(token, &basicToken) {
+		return nil, bascule.ErrInvalidCredentials
+	}
+
+	expectedPassword, ok := batp.allowed[basicToken.UserName()]
+	if !ok || basicToken.Password() != expectedPassword {
+		return nil, bascule.ErrBadCredentials
+	}
+
+	return token, nil
 }

--- a/tokenFactory_test.go
+++ b/tokenFactory_test.go
@@ -5,147 +5,131 @@ package main
 import (
 	"context"
 	"errors"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/golang-jwt/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/xmidt-org/bascule"
-	"github.com/xmidt-org/bascule/basculehttp"
 )
 
-const (
-	testAbcd        = "abcd"
-	testTokenString = "test"
-)
+func mustSignToken(t *testing.T, claims jwt.MapClaims, kid string, secret []byte) string {
+	t.Helper()
 
-func TestRawAttributesBearerTokenFactory(t *testing.T) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	if kid != "" {
+		token.Header["kid"] = kid
+	}
+
+	raw, err := token.SignedString(secret)
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	return raw
+}
+
+func TestRawAttributesBearerTokenParser(t *testing.T) {
 	tests := []struct {
-		description   string
-		value         string
-		jwtToken      *jwt.Token
-		parseCalled   bool
-		parseErr      error
-		isValid       bool
-		expectedToken bascule.Token
-		expectedErr   error
+		description       string
+		value             string
+		defaultKeyID      string
+		resolvedKeyID     string
+		resolverKey       []byte
+		resolverErr       error
+		expectedErr       error
+		expectedPrincipal string
+		expectedSub       string
 	}{
 		{
-			description: "Success",
-			value:       testAbcd,
-			jwtToken: jwt.NewWithClaims(jwt.SigningMethodHS256, &bascule.ClaimsWithLeeway{
-				MapClaims: jwt.MapClaims(
-					map[string]interface{}{
-						jwtPrincipalKey: testString,
-					},
-				),
-			}),
-			parseCalled:   true,
-			isValid:       true,
-			expectedToken: bascule.NewToken("jwt", testString, rawAttributes(map[string]interface{}{jwtPrincipalKey: testString})),
+			description:       "Success",
+			defaultKeyID:      "default-key",
+			resolvedKeyID:     "kid-1",
+			resolverKey:       []byte("secret"),
+			expectedPrincipal: "principal-1",
+			expectedSub:       "principal-1",
 		},
 		{
 			description: "Empty Value",
 			value:       "",
-			expectedErr: errors.New("empty value"),
+			expectedErr: bascule.ErrMissingCredentials,
 		},
 		{
-			description: "Parse Failed",
-			value:       testAbcd,
-			jwtToken: jwt.NewWithClaims(jwt.SigningMethodHS256, &bascule.ClaimsWithLeeway{
-				MapClaims: jwt.MapClaims(
-					map[string]interface{}{
-						jwtPrincipalKey: testString,
-					},
-				),
-			}),
-			parseCalled: true,
-			parseErr:    errors.New("parse fail test"),
-			expectedErr: errors.New("parse fail test"),
+			description: "Malformed Token",
+			value:       "not-a-jwt",
+			expectedErr: bascule.ErrInvalidCredentials,
 		},
 		{
-			description: "Invalid Token",
-			value:       testAbcd,
-			jwtToken: jwt.NewWithClaims(jwt.SigningMethodHS256, &bascule.ClaimsWithLeeway{
-				MapClaims: jwt.MapClaims(
-					map[string]interface{}{
-						jwtPrincipalKey: testString,
-					},
-				),
-			}),
-			parseCalled: true,
-			expectedErr: basculehttp.ErrInvalidToken,
+			description:   "Invalid Signature",
+			defaultKeyID:  "default-key",
+			resolvedKeyID: "kid-2",
+			resolverKey:   []byte("wrong-secret"),
+			expectedErr:   bascule.ErrInvalidCredentials,
 		},
 		{
-			description: "Unexpected Claims",
-			value:       testAbcd,
-			jwtToken: jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(
-				map[string]interface{}{
-					jwtPrincipalKey: testString,
-				},
-			)),
-			parseCalled: true,
-			isValid:     true,
-			expectedErr: basculehttp.ErrUnexpectedClaims,
+			description:   "Missing Principal",
+			defaultKeyID:  "default-key",
+			resolvedKeyID: "kid-3",
+			resolverKey:   []byte("secret"),
+			expectedErr:   bascule.ErrInvalidCredentials,
 		},
 		{
-			description: "Principal Value not Found",
-			value:       testAbcd,
-			jwtToken: jwt.NewWithClaims(jwt.SigningMethodHS256, &bascule.ClaimsWithLeeway{
-				MapClaims: jwt.MapClaims(
-					map[string]interface{}{
-						"test": testString,
-					},
-				),
-			}),
-			parseCalled: true,
-			isValid:     true,
-			expectedErr: basculehttp.ErrInvalidPrincipal,
-		},
-		{
-			description: "Principal Value not a String",
-			value:       testAbcd,
-			jwtToken: jwt.NewWithClaims(jwt.SigningMethodHS256, &bascule.ClaimsWithLeeway{
-				MapClaims: jwt.MapClaims(
-					map[string]interface{}{
-						jwtPrincipalKey: 123,
-					},
-				),
-			}),
-			parseCalled: true,
-			isValid:     true,
-			expectedErr: basculehttp.ErrInvalidPrincipal,
+			description:   "Expired Token",
+			defaultKeyID:  "default-key",
+			resolvedKeyID: "kid-4",
+			resolverKey:   []byte("secret"),
+			expectedErr:   bascule.ErrBadCredentials,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
-			r := new(MockResolver)
-			p := new(mockJWTParser)
 
-			if tc.parseCalled {
-				p.On("ParseJWT", mock.Anything, mock.Anything, mock.Anything).Return(tc.jwtToken, tc.parseErr).Once()
-				tc.jwtToken.Valid = tc.isValid
+			resolver := new(MockResolver)
+			if tc.resolvedKeyID != "" {
+				pair := new(mockKey)
+				pair.On("Public").Return(tc.resolverKey).Once()
+				resolver.On("Resolve", mock.Anything, tc.resolvedKeyID).Return(pair, tc.resolverErr).Once()
 			}
 
-			f := RawAttributesBearerTokenFactory{
-				DefaultKeyID: "default-key",
-				Resolver:     r,
-				Parser:       p,
+			value := tc.value
+			switch tc.description {
+			case "Success":
+				value = mustSignToken(t, jwt.MapClaims{jwtPrincipalKey: tc.expectedSub}, tc.resolvedKeyID, tc.resolverKey)
+			case "Invalid Signature":
+				value = mustSignToken(t, jwt.MapClaims{jwtPrincipalKey: "principal-2"}, tc.resolvedKeyID, []byte("different-secret"))
+			case "Missing Principal":
+				value = mustSignToken(t, jwt.MapClaims{"foo": "bar"}, tc.resolvedKeyID, tc.resolverKey)
+			case "Expired Token":
+				value = mustSignToken(t, jwt.MapClaims{jwtPrincipalKey: "principal-4", "exp": float64(1)}, tc.resolvedKeyID, tc.resolverKey)
 			}
 
-			req := httptest.NewRequest("get", "/", nil)
-			token, err := f.ParseAndValidate(context.Background(), req, "", tc.value)
+			parser := RawAttributesBearerTokenParser{
+				DefaultKeyID: tc.defaultKeyID,
+				Resolver:     resolver,
+			}
 
-			assert.Equal(tc.expectedToken, token)
-
-			if tc.expectedErr == nil || err == nil {
-				assert.Equal(tc.expectedErr, err)
+			token, err := parser.Parse(context.Background(), value)
+			if tc.expectedErr == nil {
+				if !assert.NoError(err) {
+					return
+				}
+				if assert.NotNil(token) {
+					assert.Equal(tc.expectedPrincipal, token.Principal())
+					accessor, ok := token.(bascule.AttributesAccessor)
+					if assert.True(ok) {
+						sub, found := accessor.Get(jwtPrincipalKey)
+						assert.True(found)
+						assert.Equal(tc.expectedSub, sub)
+					}
+				}
 			} else {
-				assert.Contains(err.Error(), tc.expectedErr.Error())
+				assert.Nil(token)
+				assert.ErrorIs(err, tc.expectedErr)
 			}
+
+			resolver.AssertExpectations(t)
 		})
 	}
 }
@@ -183,27 +167,27 @@ func TestDefaultKeyFunc(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
-			r := new(MockResolver)
+			resolver := new(MockResolver)
 			pair := new(mockKey)
 
 			pair.On("Public").Return(tc.expectedPublicKey).Once()
 
 			if tc.useDefaultKey {
-				r.On("Resolve", mock.Anything, defaultKeyID).Return(pair, tc.resolveErr).Once()
+				resolver.On("Resolve", mock.Anything, defaultKeyID).Return(pair, tc.resolveErr).Once()
 			} else {
 				tc.token.Header = map[string]interface{}{
 					"kid": "some-value",
 				}
-				r.On("Resolve", mock.Anything, "some-value").Return(pair, tc.resolveErr).Once()
+				resolver.On("Resolve", mock.Anything, "some-value").Return(pair, tc.resolveErr).Once()
 			}
 
-			publicKey, err := defaultKeyFunc(context.Background(), defaultKeyID, r)(tc.token)
+			publicKey, err := defaultKeyFunc(context.Background(), defaultKeyID, resolver)(tc.token)
 
 			assert.Equal(tc.expectedPublicKey, publicKey)
-
-			if tc.expectedErr == nil || err == nil {
-				assert.Equal(tc.expectedErr, err)
+			if tc.expectedErr == nil {
+				assert.NoError(err)
 			} else {
+				assert.Error(err)
 				assert.Contains(err.Error(), tc.expectedErr.Error())
 			}
 		})

--- a/tokenFactory_test.go
+++ b/tokenFactory_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"testing"
 	"time"
@@ -12,7 +13,21 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/xmidt-org/bascule"
+	"github.com/xmidt-org/bascule/basculehttp"
 )
+
+type stubTokenType struct {
+	principal string
+	typeName  string
+}
+
+func (stt stubTokenType) Principal() string {
+	return stt.principal
+}
+
+func (stt stubTokenType) TokenType() string {
+	return stt.typeName
+}
 
 func mustSignToken(t *testing.T, claims jwt.MapClaims, kid string, secret []byte) string {
 	t.Helper()
@@ -305,4 +320,156 @@ func TestDefaultKeyFunc(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNonEmptyPrincipalValidator(t *testing.T) {
+	tests := []struct {
+		description string
+		token       bascule.Token
+		expectErr   bool
+	}{
+		{
+			description: "Empty Principal",
+			token:       &rawAttributesJWTToken{principal: "", claims: NewRawAttributes(map[string]interface{}{})},
+			expectErr:   true,
+		},
+		{
+			description: "Non Empty Principal",
+			token:       &rawAttributesJWTToken{principal: "principal", claims: NewRawAttributes(map[string]interface{}{})},
+			expectErr:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			err := nonEmptyPrincipalValidator(tc.token)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidJWTTokenTypeValidator(t *testing.T) {
+	tests := []struct {
+		description string
+		token       bascule.Token
+		expectErr   bool
+	}{
+		{
+			description: "Missing Token Type Interface",
+			token:       bascule.StubToken("principal"),
+			expectErr:   true,
+		},
+		{
+			description: "Unexpected Token Type",
+			token:       stubTokenType{principal: "principal", typeName: "basic"},
+			expectErr:   true,
+		},
+		{
+			description: "Valid JWT Token Type",
+			token:       &rawAttributesJWTToken{principal: "principal", claims: NewRawAttributes(map[string]interface{}{})},
+			expectErr:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			err := validJWTTokenTypeValidator(tc.token)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestBasicAllowedTokenParser(t *testing.T) {
+	tests := []struct {
+		description string
+		allowed     map[string]string
+		raw         string
+		expectErr   error
+		expectUser  string
+	}{
+		{
+			description: "Invalid Base64",
+			allowed:     map[string]string{"user": "pass"},
+			raw:         "%%%",
+			expectErr:   bascule.ErrInvalidCredentials,
+		},
+		{
+			description: "Unknown User",
+			allowed:     map[string]string{"known": "pass"},
+			raw:         basculehttp.BasicAuth("unknown", "pass"),
+			expectErr:   bascule.ErrBadCredentials,
+		},
+		{
+			description: "Wrong Password",
+			allowed:     map[string]string{"user": "correct"},
+			raw:         basculehttp.BasicAuth("user", "wrong"),
+			expectErr:   bascule.ErrBadCredentials,
+		},
+		{
+			description: "Valid Credentials",
+			allowed:     map[string]string{"user": "pass"},
+			raw:         basculehttp.BasicAuth("user", "pass"),
+			expectUser:  "user",
+		},
+		{
+			description: "Missing Colon In Decoded Value",
+			allowed:     map[string]string{"user": "pass"},
+			raw:         base64.StdEncoding.EncodeToString([]byte("userpass")),
+			expectErr:   bascule.ErrInvalidCredentials,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			parser := basicAllowedTokenParser{allowed: tc.allowed}
+			token, err := parser.Parse(context.Background(), tc.raw)
+
+			if tc.expectErr != nil {
+				assert.Nil(t, token)
+				assert.ErrorIs(t, err, tc.expectErr)
+				return
+			}
+
+			if assert.NoError(t, err) && assert.NotNil(t, token) {
+				var basicToken basculehttp.BasicToken
+				if assert.True(t, bascule.TokenAs(token, &basicToken)) {
+					assert.Equal(t, tc.expectUser, basicToken.UserName())
+				}
+			}
+		})
+	}
+}
+
+func TestRawAttributesJWTTokenGet(t *testing.T) {
+	t.Run("Nil Receiver", func(t *testing.T) {
+		var token *rawAttributesJWTToken
+		value, found := token.Get("sub")
+		assert.Nil(t, value)
+		assert.False(t, found)
+	})
+
+	t.Run("Nil Claims", func(t *testing.T) {
+		token := &rawAttributesJWTToken{principal: "principal"}
+		value, found := token.Get("sub")
+		assert.Nil(t, value)
+		assert.False(t, found)
+	})
+
+	t.Run("Found Value", func(t *testing.T) {
+		token := &rawAttributesJWTToken{
+			principal: "principal",
+			claims:    NewRawAttributes(map[string]interface{}{"sub": "principal"}),
+		}
+		value, found := token.Get("sub")
+		assert.True(t, found)
+		assert.Equal(t, "principal", value)
+	})
 }

--- a/tokenFactory_test.go
+++ b/tokenFactory_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt"
 	"github.com/stretchr/testify/assert"
@@ -37,6 +38,7 @@ func TestRawAttributesBearerTokenParser(t *testing.T) {
 		resolvedKeyID     string
 		resolverKey       []byte
 		resolverErr       error
+		leeway            Leeway
 		expectedErr       error
 		expectedPrincipal string
 		expectedSub       string
@@ -80,6 +82,47 @@ func TestRawAttributesBearerTokenParser(t *testing.T) {
 			resolverKey:   []byte("secret"),
 			expectedErr:   bascule.ErrBadCredentials,
 		},
+		{
+			description:       "Expired Token With Leeway",
+			defaultKeyID:      "default-key",
+			resolvedKeyID:     "kid-5",
+			resolverKey:       []byte("secret"),
+			leeway:            Leeway{EXP: -20},
+			expectedPrincipal: "principal-5",
+			expectedSub:       "principal-5",
+		},
+		{
+			description:   "Not Before Token",
+			defaultKeyID:  "default-key",
+			resolvedKeyID: "kid-6",
+			resolverKey:   []byte("secret"),
+			expectedErr:   bascule.ErrBadCredentials,
+		},
+		{
+			description:       "Not Before Token With Leeway",
+			defaultKeyID:      "default-key",
+			resolvedKeyID:     "kid-7",
+			resolverKey:       []byte("secret"),
+			leeway:            Leeway{NBF: -20},
+			expectedPrincipal: "principal-7",
+			expectedSub:       "principal-7",
+		},
+		{
+			description:   "Issued At In Future",
+			defaultKeyID:  "default-key",
+			resolvedKeyID: "kid-8",
+			resolverKey:   []byte("secret"),
+			expectedErr:   bascule.ErrBadCredentials,
+		},
+		{
+			description:       "Issued At In Future With Leeway",
+			defaultKeyID:      "default-key",
+			resolvedKeyID:     "kid-9",
+			resolverKey:       []byte("secret"),
+			leeway:            Leeway{IAT: -20},
+			expectedPrincipal: "principal-9",
+			expectedSub:       "principal-9",
+		},
 	}
 
 	for _, tc := range tests {
@@ -94,6 +137,7 @@ func TestRawAttributesBearerTokenParser(t *testing.T) {
 			}
 
 			value := tc.value
+			now := jwt.TimeFunc().Unix()
 			switch tc.description {
 			case "Success":
 				value = mustSignToken(t, jwt.MapClaims{jwtPrincipalKey: tc.expectedSub}, tc.resolvedKeyID, tc.resolverKey)
@@ -103,11 +147,22 @@ func TestRawAttributesBearerTokenParser(t *testing.T) {
 				value = mustSignToken(t, jwt.MapClaims{"foo": "bar"}, tc.resolvedKeyID, tc.resolverKey)
 			case "Expired Token":
 				value = mustSignToken(t, jwt.MapClaims{jwtPrincipalKey: "principal-4", "exp": float64(1)}, tc.resolvedKeyID, tc.resolverKey)
+			case "Expired Token With Leeway":
+				value = mustSignToken(t, jwt.MapClaims{jwtPrincipalKey: "principal-5", "exp": float64(now - 10)}, tc.resolvedKeyID, tc.resolverKey)
+			case "Not Before Token":
+				value = mustSignToken(t, jwt.MapClaims{jwtPrincipalKey: "principal-6", "nbf": float64(now + 10)}, tc.resolvedKeyID, tc.resolverKey)
+			case "Not Before Token With Leeway":
+				value = mustSignToken(t, jwt.MapClaims{jwtPrincipalKey: "principal-7", "nbf": float64(now + 10)}, tc.resolvedKeyID, tc.resolverKey)
+			case "Issued At In Future":
+				value = mustSignToken(t, jwt.MapClaims{jwtPrincipalKey: "principal-8", "iat": float64(now + 10)}, tc.resolvedKeyID, tc.resolverKey)
+			case "Issued At In Future With Leeway":
+				value = mustSignToken(t, jwt.MapClaims{jwtPrincipalKey: "principal-9", "iat": float64(now + 10)}, tc.resolvedKeyID, tc.resolverKey)
 			}
 
 			parser := RawAttributesBearerTokenParser{
 				DefaultKeyID: tc.defaultKeyID,
 				Resolver:     resolver,
+				Leeway:       tc.leeway,
 			}
 
 			token, err := parser.Parse(context.Background(), value)
@@ -130,6 +185,64 @@ func TestRawAttributesBearerTokenParser(t *testing.T) {
 			}
 
 			resolver.AssertExpectations(t)
+		})
+	}
+}
+
+func TestValidateTimeClaimsWithLeeway(t *testing.T) {
+	originalTimeFunc := jwt.TimeFunc
+	jwt.TimeFunc = func() time.Time { return time.Unix(1000, 0) }
+	t.Cleanup(func() { jwt.TimeFunc = originalTimeFunc })
+
+	tests := []struct {
+		description string
+		claims      jwt.MapClaims
+		leeway      Leeway
+		expectErr   bool
+	}{
+		{
+			description: "Expired Without Leeway",
+			claims:      jwt.MapClaims{"exp": float64(999)},
+			expectErr:   true,
+		},
+		{
+			description: "Expired With Leeway",
+			claims:      jwt.MapClaims{"exp": float64(999)},
+			leeway:      Leeway{EXP: -5},
+			expectErr:   false,
+		},
+		{
+			description: "Not Before Without Leeway",
+			claims:      jwt.MapClaims{"exp": float64(2000), "nbf": float64(1005)},
+			expectErr:   true,
+		},
+		{
+			description: "Not Before With Leeway",
+			claims:      jwt.MapClaims{"exp": float64(2000), "nbf": float64(1005)},
+			leeway:      Leeway{NBF: -10},
+			expectErr:   false,
+		},
+		{
+			description: "Issued At In Future Without Leeway",
+			claims:      jwt.MapClaims{"exp": float64(2000), "iat": float64(1005)},
+			expectErr:   true,
+		},
+		{
+			description: "Issued At In Future With Leeway",
+			claims:      jwt.MapClaims{"exp": float64(2000), "iat": float64(1005)},
+			leeway:      Leeway{IAT: -10},
+			expectErr:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			err := validateTimeClaimsWithLeeway(tc.claims, tc.leeway)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Closes https://github.com/comcast-cl/xmidt/issues/6450

- Upgraded Bascule from v0.11.7 to v1.1.1 and updated auth integration in Talaria to work with V1.
- Refactored auth wiring in primaryHandler.go to the new bascule v1 pattern
- Reworked JWT parsing in tokenFactory.go and updated context/claims in middleware.go and rawAttributes.go to match bascule v1 interfaces

